### PR TITLE
Fix colorizing with set_highlight_whitespace(false).

### DIFF
--- a/src/lcs.rs
+++ b/src/lcs.rs
@@ -103,13 +103,13 @@ where
         table.set_titles(Row::new(
             header.into_iter().map(|i| Cell::new(&i)).collect(),
         ));
-        for j in 0..self.y.len() + 1 {
+        for j in 0..=self.y.len() {
             let mut row = vec![if j == 0 {
                 "Ø".to_string()
             } else {
                 format!("{}", self.y[j - 1])
             }];
-            for i in 0..self.x.len() + 1 {
+            for i in 0..=self.x.len() {
                 row.push(format!("{}", self.table[i][j]));
             }
             table.add_row(row.into_iter().map(|i| Cell::new(&i)).collect());

--- a/src/text.rs
+++ b/src/text.rs
@@ -116,7 +116,7 @@ pub fn diff_words<'a>(old: &'a str, new: &'a str) -> InlineChangeset<'a> {
 }
 
 fn color_multilines(color: Colour, s: &str) -> String {
-    s.split("\n")
+    s.split('\n')
         .map(|i| color.paint(i).to_string())
         .collect::<Vec<_>>()
         .join("\n")
@@ -182,31 +182,32 @@ impl<'a> LineChangeset<'a> {
         let mut start = 0;
         let mut stop = a.len();
         if self.trim_new_lines {
-            for i in start..stop {
-                if a[i] != "" {
+            for (index, element) in a.iter().enumerate() {
+                if *element != "" {
                     break;
                 }
-                start = i + 1;
+                start = index + 1;
             }
-            for i in (start..stop).rev() {
-                if a[i] != "" {
+            for (index, element) in a[start..stop].iter().rev().enumerate() {
+                if *element != "" {
                     break;
                 }
-                stop = i;
+                stop = index;
             }
         }
         let out = &a[start..stop];
         if let Some(color) = color {
-            return (
+            (
                 out.iter()
                     .map(|i| color.paint(*i).to_string())
                     .collect::<Vec<String>>()
                     .join("\n")
                     .replace("\t", "    "),
                 start,
-            );
+            )
+        } else {
+            (out.join("\n").replace("\t", "    "), start)
         }
-        (out.join("\n").replace("\t", "    "), start)
     }
     fn prettytable_process_replace(
         &self,

--- a/src/text.rs
+++ b/src/text.rs
@@ -40,31 +40,27 @@ impl<'a> InlineChangeset<'a> {
         basic::diff(&self.old, &self.new)
     }
 
-    fn color_whitespace(&self, bg_color: Colour, style: Style, a: &[&str]) -> String {
-        let mut out = a.join(self.separator);
-        if self.highlight_whitespace {
-            out = out
-                .chars()
-                .map(|i| {
-                    if i.is_whitespace() {
-                        Colour::White.on(bg_color).paint(i.to_string()).to_string()
-                    } else {
-                        style.paint(i.to_string()).to_string()
-                    }
-                })
-                .collect::<Vec<String>>()
-                .join("");
-        }
-        out
+    fn apply_style(&self, bg_color: Colour, style: Style, a: &[&str]) -> String {
+        a.join(self.separator)
+            .chars()
+            .map(|i| {
+                if i.is_whitespace() && self.highlight_whitespace {
+                    Colour::White.on(bg_color).paint(i.to_string()).to_string()
+                } else {
+                    style.paint(i.to_string()).to_string()
+                }
+            })
+            .collect::<Vec<String>>()
+            .join("")
     }
 
     fn remove_color(&self, a: &[&str]) -> String {
-        self.color_whitespace(Colour::Red, Colour::Red.strikethrough(), a)
+        self.apply_style(Colour::Red, Colour::Red.strikethrough(), a)
 
     }
 
     fn insert_color(&self, a: &[&str]) -> String {
-        self.color_whitespace(Colour::Green, Colour::Green.normal(), a)
+        self.apply_style(Colour::Green, Colour::Green.normal(), a)
     }
     /// Returns formatted string with colors
     pub fn format(&self) -> String {


### PR DESCRIPTION
Hi, I tried to disable the coloring of whitespaces and thought this should do it:

```rust
let diff = diff_words(w[0].1, w[1].1).set_highlight_whitespace(false);
println!("[{}]\n{}", w[1].0, diff);
```

but it did not. It disabled all colors/styles. I fixed it and also made a commit to silence clippy. Clippy is really useful for beginners and all others alike, and most IDEs support it. You may want to check it out if you do not know it yet. (https://github.com/rust-lang/rust-clippy)

The first commit fixes the problem. Test are running through, but I did not always check if every part I changed was tested by those tests. Also, my short use case is running well with it. Good thing the tests were there, this way I was more confident in not breaking anything :D The second commit changes the code where clippy threw warnings. It makes the code more rusty, which mostly avoids eventual simple human errors in code (i.e. when using indices) and improves readablilty.

I hope you like it. In case you do not like the new function name or so just tell me, I'll quick fix it :)