### PR TITLE
Re-export style struct within text module.

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -1,7 +1,9 @@
 //! Utils for diff text
+pub use ansi_term::Style;
+
 use crate::basic;
 use crate::format_table;
-use ansi_term::{Colour, Style};
+use ansi_term::{Colour};
 use prettytable::{Cell, Row};
 use std::fmt;
 


### PR DESCRIPTION
You recently added the possibility to set the style for insertions or removals (which is neat!), so I tried it out. Problem: To create a style, I need to create a `Style` struct, but I could not access it via your crate (I hope I did not just miss it). So I would need to add ansi_term to the dependencies of my own application. To be compatible I need to specify a version in `cargo.toml` which is compatible. Which often is not a big deal, because cargo is pretty smart with its semantic versioning thing.

Usually though, libraries simply re-export such structs so you can just import and use it. This re-export will also be automatically added to the documentation. And this is what I did here. You can now do for example:

```rust
use prettydiff::text::{diff_words, Style};
// or: use prettydiff::{diff_words, text::Style}
main() {
    let insert_style = Style::new().bold().blink();
    let diff = diff_words(a, b)
        .set_highlight_whitespace(false)
        .set_insert_style(insert_style);
}
```

Note that I just decided to export it within the text module. It is yours to decide how to do this, so feel free to tell me how you would like to do it, I will change it accordingly :) 