### PR TITLE
`prettytable_process` bugfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ required-features = ["cli"]
 
 [package]
 name = "prettydiff"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Roman Koblov <penpen938@me.com>"]
 edition = "2018"
 description = "Side-by-side diff for two files"

--- a/src/text.rs
+++ b/src/text.rs
@@ -274,11 +274,11 @@ impl<'a> LineChangeset<'a> {
                 }
                 start = index + 1;
             }
-            for (index, element) in a[start..stop].iter().rev().enumerate() {
+            for (index, element) in a.iter().enumerate().rev() {
                 if *element != "" {
+                    stop = index + 1;
                     break;
                 }
-                stop = index;
             }
         }
         let out = &a[start..stop];

--- a/src/text.rs
+++ b/src/text.rs
@@ -639,3 +639,24 @@ fn test_diff_words_issue_1() {
         ],
     );
 }
+
+#[test]
+fn test_prettytable_process() {
+    let d1 = diff_lines(
+        r#"line1
+        line2
+        line3
+        "#,
+        r#"line1
+        line2
+        line2.5
+        line3
+        "#,
+    );
+
+    println!("diff_lines: {} {:?}", d1, d1.diff());
+    assert_eq!(d1.prettytable_process(&["a", "b", "c"], None), (String::from("a\nb\nc"), 0));
+    assert_eq!(d1.prettytable_process(&["a", "b", "c", ""], None), (String::from("a\nb\nc"), 0));
+    assert_eq!(d1.prettytable_process(&["", "a", "b", "c"], None), (String::from("a\nb\nc"), 1));
+    assert_eq!(d1.prettytable_process(&["", "a", "b", "c", ""], None), (String::from("a\nb\nc"), 1));
+}


### PR DESCRIPTION
When `prettytable_process` is called with whitespace, the wrong result is computed and may even lead to a panic.