### PR TITLE
Bump prettytables to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ homepage = "https://github.com/romankoblov/prettydiff"
 
 [dependencies]
 ansi_term.version = "0.12"
-prettytable-rs.version = "0.8.0"
+prettytable-rs.version = "0.10.0"
 structopt.version = "0.3"
 
 prettytable-rs.optional = true


### PR DESCRIPTION
Fixes some latest nightly builds and gets rid of unsafe API