### PR TITLE
Add function to format LineChangeSet with a limited context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ homepage = "https://github.com/romankoblov/prettydiff"
 
 [dependencies]
 ansi_term.version = "0.12"
+pad = "0.1.6"
 prettytable-rs.version = "0.10.0"
 structopt.version = "0.3"
 


### PR DESCRIPTION
This new `format_with_context` function takes two arguments:
- an optional `ContextConfig` argument, which contains a `context_size` and a `skipping_marker`. If it is set, then lines in the change set that are equal are only displayed if they are within `context_size` lines of an actual modification, and `skipping_marker` is printed to indicate where lines have been skipped.
- a `display_line_numbers` boolean argument, which indicates whether to display line numbers of the reference text (the left one) in the formatted output.

The global behaviour of `format_with_context` is similar to that of the POSIX command `diff -C`.

This is an example of a diff rendered with
```rust
format_with_context(
    Some(ContextConfig{
        context_size: 1,
        skipping_marker: "...",
    }),
    true // display_line_numbers
)
```
![image](https://user-images.githubusercontent.com/38809035/230147138-04fb4b48-849b-41df-8d70-222c422419b9.png)

To do:
- [x] Add skipping marker (_e.g._ `[...]`)
- [x] Add line numbers

Closes #12